### PR TITLE
Hotfix for db connection timeout

### DIFF
--- a/src/schema.py
+++ b/src/schema.py
@@ -39,9 +39,12 @@ class EventType(enum.Enum):
 
 # Initialization Steps
 SQLBase = db.ext.declarative.declarative_base()
-sqlengine = db.create_engine(SQL_URL)
+sqlengine = db.create_engine(SQL_URL,pool_recycle=1440,pool_pre_ping=True)
 SQLBase.metadata.bind = sqlengine
 session = db.orm.sessionmaker(bind=sqlengine)()  # main object used for queries
+
+# Implement schema
+SQLBase.metadata.create_all(sqlengine)
 
 # Main primitives
 class Event(SQLBase):
@@ -182,6 +185,3 @@ class EventEmail(SQLBase): #Map event email to parsed Event entry
     message_id = Column(String(EMAIL_MESSAGE_ID_LENGTH), primary_key = True, unique=True)
     event_id = Column(Integer, ForeignKey("events.id"),nullable=False)
     event = relationship("Event")
-
-# Implement schema
-SQLBase.metadata.create_all(sqlengine)


### PR DESCRIPTION
**Issue:** A query that is done after a long period of inactivity are returning OperationalError("MySQL Connection not available."). Then in subsequent requests SQLalchemy requires for the session to do session.rollback() before additional queries can be done.

**Fix:** From what I can tell this issue is caused by the connection timing out. As a fix, I took the "pessimistic" approach of dealing with disconnects and tacked on `pool_pre_ping=True` to force the server to test ping on the connection to see if it is still alive, and re-establishing a new one of not. This adds a "SELECT 1" query to every command, which I considered to be an acceptable overhead. Also for safety I matched the `pool_recycle` parameter to match the login cookie timeout on the MySQL server configs.