### PR TITLE
Hotfix v2 for timeout

### DIFF
--- a/src/db.py
+++ b/src/db.py
@@ -61,6 +61,7 @@ def get_events_by_date(from_date):
     from_date: datetime Date object for target day
     '''
     to_date = from_date + timedelta(days=1)
+    
     events = session.query(
             Event
         ).filter(

--- a/src/main.py
+++ b/src/main.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     uvicorn.run("main:app",
                 host=config.SERVER_HOST,
                 port=config.SERVER_PORT,
-                reload=True,
+                reload=False, #More optimized for production
                 ssl_keyfile=config.SSL_KEY_FILE,
                 ssl_certfile=config.SSL_CRT_FILE
                 )

--- a/src/schema.py
+++ b/src/schema.py
@@ -1,9 +1,11 @@
 import datetime
+
 import configs.creds as creds
 import enum
 
 #SQLAlchemy
-import sqlalchemy as db
+import sqlalchemy
+import sqlalchemy.orm
 import sqlalchemy.ext.declarative
 from sqlalchemy import Column, Integer, String, ForeignKey, Boolean, DateTime, Text, Date, Time, Enum
 from sqlalchemy.orm import relationship
@@ -38,10 +40,11 @@ class EventType(enum.Enum):
 ##############################################################
 
 # Initialization Steps
-SQLBase = db.ext.declarative.declarative_base()
-sqlengine = db.create_engine(SQL_URL,pool_recycle=1440,pool_pre_ping=True)
+SQLBase = sqlalchemy.ext.declarative.declarative_base()
+sqlengine = sqlalchemy.create_engine(SQL_URL,pool_recycle=1200,pool_pre_ping=True)
 SQLBase.metadata.bind = sqlengine
-session = db.orm.sessionmaker(bind=sqlengine)()  # main object used for queries
+session = sqlalchemy.orm.sessionmaker(bind=sqlengine)  # main object used for queries
+session = sqlalchemy.orm.scoped_session(session) #We use scoped_session for thread safety
 
 # Implement schema
 SQLBase.metadata.create_all(sqlengine)


### PR DESCRIPTION
- Use `scope_session` in SQLalchemy for thread safety
- Decrease connection pool length
- Turn off auto-reload for more optimized production deployment
- Clarify package name in schema.py