### PR TITLE
Set CORS to temporarily allow all origins

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -32,7 +32,8 @@ app = FastAPI()
 
 app.add_middleware(
     CORSMiddleware,
-    allow_headers=["*"]
+    allow_headers=["*"],
+    allow_origins=["*"]
 )
 
 @app.get("/")


### PR DESCRIPTION
For the sake of testing, we're setting our CORS policy to allow all methods (not just GET) and all origins (including localhost).