### PR TITLE
Hotfix: Decode MIME quoted-printable data event descriptions 

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,1 +1,2 @@
 from . import utils
+from . import db

--- a/src/db/db_operations.py
+++ b/src/db/db_operations.py
@@ -303,11 +303,38 @@ def add_event_email(session,event_id,message_id,in_reply_to):
 
 ## Update functions
 
+def update_event_description(session, event_id, description, description_html):
+    '''
+    Update descriptions for an existing event with id `event_id` in the database
+    
+    Returns whether update was successful
+    '''
+    event = session.query(Event).filter(Event.id==event_id).first()
+    if not event: 
+        return False #Event doesn't exist
+    
+    error=False
+    # Attempt to make corresponding updates
+    try: 
+        event.description = description
+        event.description_html = description_html
+    except:
+        session.rollback()
+        error=True
+    else:
+        session.commit()
+    
+    return not error
+
 def update_event(session, event_id, title, description, event_tags=None,\
                 start_date=None, end_date=None, start_time=None, end_time=None, \
                 description_html=None, club_id=None, location=None, cta_link=None):
     '''
     Update an existing event with id `event_id` in the database
+    
+    Note: Use this function if you are updating many different
+    aspects of an event at once. Otherwise, it is preferable to
+    use a more specific update function.
     
     Disallowed fields:
     - user_id, club_id
@@ -348,4 +375,3 @@ def update_event(session, event_id, title, description, event_tags=None,\
         add_event_tags(session, event_id, event_tags)
     
     return not error
-    

--- a/src/hotfixes/06-17-23_MIME_Encoded/fix.py
+++ b/src/hotfixes/06-17-23_MIME_Encoded/fix.py
@@ -1,0 +1,28 @@
+import email
+import sys
+from xxlimited import new
+sys.path.append('/home/huydai/Documents/SIPB/dormdigest-backend/src') #Hardcoded
+
+import db.db_operations as db_operations
+import quopri
+import utils.email_parser as email_parser
+
+def decode_events_description():
+    with db_operations.session_scope() as session:
+        all_events = db_operations.get_all_events(session)
+        for event in all_events:
+            if event.description_html: #MIME-encoding is only in emails with HTML description
+                #print("Original HTML:\n",event.description_html)
+                new_description_html = quopri.decodestring(event.description_html.encode('utf-8')).decode('utf-8',"ignore")
+                #print("\n\nNew HTML:\n",new_description_html)
+                event.description_html = new_description_html
+                event.description = email_parser.html2text(new_description_html)
+                #print("New plain",event.description)
+        session.commit()
+        session.flush()
+
+
+
+if __name__ == '__main__':
+    
+    decode_events_description()

--- a/src/hotfixes/README.md
+++ b/src/hotfixes/README.md
@@ -1,0 +1,8 @@
+# Hotfixes
+
+This directory contains code for hotfixes we had to do for the dormdigest backend. They are preserved here in case we may need to reuse tools/code here again.
+
+Directory:
+
+- **06-17-23_MIME_Encoded**
+  - **Issue:** Event emails stored in the database were in MIME quoted-printable data form, and needs to be decoded for proper display on the dormdigest frontend.

--- a/src/utils/email_parser.py
+++ b/src/utils/email_parser.py
@@ -145,7 +145,6 @@ class Email:
             return self.content["text/plain"]
         elif "text/html" in self.content:
             return html2text(self.content["text/html"])
-        
         return ""
 
     @property


### PR DESCRIPTION
Event emails stored in the database were in MIME quoted-printable data form, and needs to be decoded for proper display on the dormdigest frontend.